### PR TITLE
Fix #38 and fix compatibility with calibre-web

### DIFF
--- a/calibre_plugin/model.py
+++ b/calibre_plugin/model.py
@@ -75,7 +75,10 @@ class OpdsBooksModel(QAbstractTableModel):
                 reason = str(exception.reason)
             error_dialog(gui, _('Failed opening the OPDS URL'), message, reason, displayDialogOnErrors)
             return (None, {})
-        self.serverHeader = feed.headers['server']
+        if 'server' in feed.headers:
+            self.serverHeader = feed.headers['server']
+        else:
+            self.serverHeader = "none"
         print("serverHeader: %s" % self.serverHeader)
         print("feed.entries: %s" % feed.entries)
         catalogEntries = {}
@@ -148,7 +151,10 @@ class OpdsBooksModel(QAbstractTableModel):
         authors = opdsBookStructure.author.replace(u'& ', u'&') if 'author' in opdsBookStructure else ''
         metadata = Metadata(opdsBookStructure.title, authors.split(u'&'))
         metadata.uuid = opdsBookStructure.id.replace('urn:uuid:', '', 1) if 'id' in opdsBookStructure else ''
-        rawTimestamp = opdsBookStructure.updated
+        try:
+            rawTimestamp = opdsBookStructure.updated
+        except AttributeError:
+            rawTimestamp = "1980-01-01T00:00:00+00:00"
         parsableTimestamp = re.sub('((\.[0-9]+)?\+0[0-9]:00|Z)$', '', rawTimestamp)
         metadata.timestamp = datetime.datetime.strptime(parsableTimestamp, '%Y-%m-%dT%H:%M:%S')
         tags = []

--- a/calibre_plugin/ui.py
+++ b/calibre_plugin/ui.py
@@ -25,6 +25,6 @@ class OpdsInterfacePlugin(InterfaceAction):
         d.show()
 
     def apply_settings(self):
-        from config import prefs
+        from calibre_plugins.opds_client.config import prefs
         prefs
 


### PR DESCRIPTION
This PR fixes #38 and fixes compatibility with calibre-web by making a couple checks against the feed optional. I haven't tested it super thoroughly so I don't know if any other checks need to be fixed but I added fallback values in case a feed doesn't have the "server" or "updated" keys present.

A couple tips in case anyone in the future is reading this and struggling to get calibre-web to play nicely with the plugin:
- Make sure Enable Anonymous Browsing is turned on. Authentication isn't yet implemented in this plugin (See #30).
- I've found that it works best to point the plugin at `http://url-of-server/opds/books` then select "All" in the dropdown and press Download OPDS. This grabs the full library (limits may exist, unsure) in alphabetical order.